### PR TITLE
feat: add 'collaborations'

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -11,3 +11,11 @@
   publisher={Courier Corporation,},
   preview={brownian-motion.gif}
 }
+
+@inproceedings{yrjanainen2024swedish,
+  title={The Swedish Parliament Corpus 1867 -- 2022},
+  author={Yrjänäinen, Väinö, and Mohammadi Norén, Fredrik and Borges, Robert and Jarlbrink, Johan and Åberg Brorsson, Lotta and P. Olsson, Anders and Snickars, Pelle and Magnusson Måns},
+  booktitle={LREC 2024 proceedings},
+  note={Accepted, to be published},
+  year={2024}
+}

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -12,10 +12,28 @@
   preview={brownian-motion.gif}
 }
 
-@inproceedings{yrjanainen2024swedish,
-  title={The Swedish Parliament Corpus 1867 -- 2022},
-  author={Yrjänäinen, Väinö, and Mohammadi Norén, Fredrik and Borges, Robert and Jarlbrink, Johan and Åberg Brorsson, Lotta and P. Olsson, Anders and Snickars, Pelle and Magnusson Måns},
-  booktitle={LREC 2024 proceedings},
-  note={Accepted, to be published},
-  year={2024}
+@inproceedings{yrjanainen-etal-2024-swedish-parliament,
+    title = "The {S}wedish Parliament Corpus 1867 {--} 2022",
+    author = {Yrj{\"a}n{\"a}inen, V{\"a}in{\"o} Aleksi  and
+      Mohammadi Nor{\'e}n, Fredrik  and
+      Borges, Robert  and
+      Jarlbrink, Johan  and
+      {\AA}berg Brorsson, Lotta  and
+      Olsson, Anders P.  and
+      Snickars, Pelle  and
+      Magnusson, M{\aa}ns},
+    editor = "Calzolari, Nicoletta  and
+      Kan, Min-Yen  and
+      Hoste, Veronique  and
+      Lenci, Alessandro  and
+      Sakti, Sakriani  and
+      Xue, Nianwen",
+    booktitle = "Proceedings of the 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation (LREC-COLING 2024)",
+    month = may,
+    year = "2024",
+    address = "Torino, Italy",
+    publisher = "ELRA and ICCL",
+    url = "https://aclanthology.org/2024.lrec-main.1400",
+    pages = "16100--16112",
+    abstract = "The Swedish parliamentary records are an important source material for social science and humanities researchers. We introduce a new research corpus, the Swedish Parliament Corpus, which is larger and more developed than previously available research corpora for the Swedish parliament. The corpus contains annotated and structured parliamentary records over more than 150 years, through the bicameral parliament (1867{--}1970) and the unicameral parliament (1971{--}). In addition to the records, which contain all speeches in the parliament, we also provide a database of all members of parliament over the same period. Along with the corpus, we describe procedures to ensure data quality. The corpus facilitates detailed analysis of parliamentary speeches in several research fields.",
 }

--- a/_data/repositories.yml
+++ b/_data/repositories.yml
@@ -2,5 +2,8 @@ github_users:
   - swerik-project
 
 github_repos:
-  - welfare-state-analytics/riksdagen-corpus
+  - swerik-project/the-swedish-parliament-corpus
+  - swerik-project/riksdagen-records
+  - swerik-project/riksdagen-politicians
+  - swerik-project/pyriksdagen
   - swerik-project/swerik-project.github.io

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -3,6 +3,7 @@ layout: about
 title: Swerik
 permalink: /
 subtitle: Research infrastructure project funded by Riksbankens Jubileumsfond
+nav: false
 
 profile:
   align: ""

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -10,7 +10,9 @@ nav_order: 1
 
 Swerik welcomes collaborations with research projects and individual scholars. Our working ideology is that researchers who work with the parliamentary infrastructure will also make it better.
 
-## Collaboration with research projects investing resources in Swerik
+<br>
+
+#### Collaboration with research projects investing resources in Swerik
 
 _What does it take to make leadership gender equal? Studies of political leadership in a gender balanced context_. PI: Josefina Eriksson (Uppsala University). Funder: The Swedish Research Council (2023–2026). Swerik collaboration: annotate interpellation debates.
 
@@ -18,7 +20,9 @@ _What will we eat? Food as a security policy issue in Sweden 1900–2025._ PI: J
 
 _Extending SWERIK_. PI: Måns Magnusson (Uppsala University). Funder: Centre for Digital Humanities and Social Sciences at Uppsala University (spring of 2024). Swerik collaboration: improve the segmentation of Swedish parliamentary speeches 1867–2023.
 
-## Collaborations with other research projects
+<br>
+
+#### Collaborations with other research projects
 
 _Political Representation: Tensions between Parliament and the People from the Age of Revolutions to the 21st Century_. PI: Pasi Ihalainen (Jyväskylä University). Funder: Research Council of Finland (2021–2026). Swerik collaboration: use Swerik data for an interface to explore different national parliamentary speeches.
 

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -1,18 +1,31 @@
 ---
 layout: page
-permalink: /publications/
-title: Publications
-description: SWERIK project publications
+permalink: /collaborations/
+title: Collaborations
+description: ""
 years: []
 nav: true
 nav_order: 1
 ---
-<!-- _pages/publications.md -->
-<div class="publications">
 
-{%- for y in page.years %}
-  <h2 class="year">{{y}}</h2>
-  {% bibliography -f papers -q @*[year={{y}}]* %}
-{% endfor %}
+Swerik welcomes collaborations with research projects and individual scholars. Our working ideology is that researchers who work with the parliamentary infrastructure will also make it better.
 
-</div>
+## Collaboration with research projects investing resources in Swerik
+
+_What does it take to make leadership gender equal? Studies of political leadership in a gender balanced context_. PI: Josefina Eriksson (Uppsala University). Funder: The Swedish Research Council (2023–2026). Swerik collaboration: annotate interpellation debates.
+
+_What will we eat? Food as a security policy issue in Sweden 1900–2025._ PI: Johanna Pettersson Fürst (Uppsala University). Funder: The Swedish Research Council (2023–2027). Swerik collaboration: run topic models on parliamentary data.
+
+_Extending SWERIK_. PI: Måns Magnusson (Uppsala University). Funder: Centre for Digital Humanities and Social Sciences at Uppsala University (spring of 2024). Swerik collaboration: improve the segmentation of Swedish parliamentary speeches 1867–2023.
+
+## Collaborations with other research projects
+
+_Political Representation: Tensions between Parliament and the People from the Age of Revolutions to the 21st Century_. PI: Pasi Ihalainen (Jyväskylä University). Funder: Research Council of Finland (2021–2026). Swerik collaboration: use Swerik data for an interface to explore different national parliamentary speeches.
+
+_Swedish Parliamentary Debates (SweDeb)_. PI: Fredrik Mohammadi Norén (Malmö University). Funder: Umeå University (2023–2024). Swerik collaboration: use Swerik data for an interface to explore different national parliamentary speeches.
+
+_Welfare State Analytics. Text Mining and Modeling Swedish Politics, Media & Culture, 1945–1989 (WeStAc)_. PI: Pelle Snickars (Lund University). Funder: The Swedish Research Council (2019–2024). Swerik collaboration: the Swerik project originated from the WeStAc project, which also use its parliamentary speech data for research.
+
+_Terrorism in Swedish politics: a multimodal study of the configuration of terrorism in parliamentary debates, legislation, and policy networks in Sweden 1968–2018 (SweTerror)_. PI: Jens Edlund (KTH). Funder: The Swedish Research Council (2021–2024). Swerik collaboration: use its parliamentary speech data for research, and help out to improve the speech data and the MP database.
+
+_A complete dataset of roll-call votes in the Swedish parliament, 1925–2022_. PI: Jan Teorell (Stockholm University). Funder: Riksbankens Jubileumsfond (2023). Swerik collaboration: add MP chair metadata and help out to improve party information to the MP database.

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -1,13 +1,29 @@
 ---
 layout: page
 permalink: /data-and-code/
-title: "Data & Code"
-description: Data and source code associated with the SWERIK project
+title: "Data, Code & Publications"
+description: ""
 nav: true
+years: [2024]
 nav_order: 3
 ---
 
+The most recent release of The Swedish Parliament Corpus can be accessed <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/latest">here</a>.
+
+You can also directly download the corpus in
+- The records in the <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/download/latest/records.zip">ParlaClarin format</a>
+- The metadata in the <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/download/latest/dumps.zip">CSV format</a>
+
+<h2 class="repos">Publications</h2>
+<div class="publications">
+{%- for y in page.years %}
+  <h2 class="year">{{y}}</h2>
+  {% bibliography -f papers -q @*[year={{y}}]* %}
+{% endfor %}
+</div>
+
 {% if site.data.repositories.github_repos %}
+<h2 class="repos">Source code</h2>
 <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
   {% for repo in site.data.repositories.github_repos %}
     {% include repository/repo.html repository=repo %}

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -11,8 +11,8 @@ nav_order: 3
 The most recent release of The Swedish Parliament Corpus can be accessed <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/latest">here</a>.
 
 You can also directly download the corpus in
-- The records in the <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/download/latest/records.zip">ParlaClarin format</a>
-- The metadata in the <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/download/latest/dumps.zip">CSV format</a>
+- The records in the <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/latest/download/records.zip">ParlaClarin format</a>
+- The metadata in the <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/latest/download/dumps.zip">CSV format</a>
 
 <h2 class="repos">Publications</h2>
 <div class="publications">

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 permalink: /data-and-code/
-title: "Data, Code & Publications"
+title: "Publications, Data & Code"
 description: ""
 nav: true
 years: [2024]
@@ -14,7 +14,10 @@ You can also directly download the corpus in
 - The records in the <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/latest/download/records.zip">ParlaClarin format</a>
 - The metadata in the <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/latest/download/dumps.zip">CSV format</a>
 
-<h2 class="repos">Publications</h2>
+<br>
+
+### Publications
+
 <div class="publications">
 {%- for y in page.years %}
   <h2 class="year">{{y}}</h2>
@@ -23,7 +26,9 @@ You can also directly download the corpus in
 </div>
 
 {% if site.data.repositories.github_repos %}
-<h2 class="repos">Source code</h2>
+
+### Source code
+
 <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
   {% for repo in site.data.repositories.github_repos %}
     {% include repository/repo.html repository=repo %}

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-permalink: /data-and-code/
-title: "Publications, Data & Code"
+permalink: /data-publications-and-code/
+title: "Data, Publications, & Code"
 description: ""
 nav: true
 years: [2024]
@@ -9,10 +9,6 @@ nav_order: 3
 ---
 
 The most recent release of The Swedish Parliament Corpus can be accessed <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/latest">here</a>.
-
-You can also directly download the corpus in
-- The records in the <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/latest/download/records.zip">ParlaClarin format</a>
-- The metadata in the <a href="https://github.com/swerik-project/the-swedish-parliament-corpus/releases/latest/download/dumps.zip">CSV format</a>
 
 <br>
 


### PR DESCRIPTION
Resolves https://github.com/welfare-state-analytics/riksdagen-corpus/issues/484 . Here are screenshots of the new version:

<img width="829" alt="Screenshot 2024-04-08 at 16 09 20" src="https://github.com/swerik-project/swerik-project.github.io/assets/10169469/805917e9-fd5d-4d08-8da4-73df392c608f">

<img width="849" alt="Screenshot 2024-04-08 at 16 09 33" src="https://github.com/swerik-project/swerik-project.github.io/assets/10169469/d0082981-3634-40fb-98f3-9d6d670bf9c0">

We probably want to hide the publications section right now. It can be brought back later.