### PR TITLE
fix: 'swerik_id' vs. 'person_id' key mismatch

### DIFF
--- a/_includes/person-catalog-landing.html
+++ b/_includes/person-catalog-landing.html
@@ -3,7 +3,7 @@
 <ul>
 {% for p in d.names %}
   <li>
-    <a href="/person-catalog/{{ p.swerik_id }}" target="_blank">
+    <a href="/person-catalog/{{ p.person_id }}" target="_blank">
       {{ p.name | titlecase }}
     </a>
     (born {{ p.born }})


### PR DESCRIPTION
The page template was using the old key, I think this will fix it.

The links on the catalog landing page are broken right now due to this.